### PR TITLE
hotfix for column names with history

### DIFF
--- a/geoNEON/R/getLocValues.R
+++ b/geoNEON/R/getLocValues.R
@@ -40,9 +40,9 @@ getLocValues <- function(locJSON, history=F) {
                     rep(locJSON$data$locationName, nrow(loc.values)), 
                     rep(locJSON$data$domainCode, nrow(loc.values)), 
                     rep(locJSON$data$siteCode, nrow(loc.values)))
-    names(locids) <- c('locationDescription', 'locationName', 'domainCode', 'siteCode')
     loc.values <- cbind(locids, loc.values)
-
+    names(loc.values)[1:4] <- c('locationDescription', 'locationName', 'domainCode', 'siteCode')
+    
     if(length(locJSON$data$locationHistory$locationProperties[[1]])!=0) {
       loc.props.list <- lapply(locJSON$data$locationHistory$locationProperties, tLocProps)
       loc.props <- data.table::rbindlist(loc.props.list, fill=T)


### PR DESCRIPTION
Hi @cklunch ,

This is a tiny fix to make sure the first 4 column names are added in `getLocValues` if `history = TRUE`. Assigning the names to the vector locids wasn't coming through as column names after cbind with loc.values. 